### PR TITLE
Add MNIST digit classification model training capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,25 @@ The CLI 3 command consumes data incoming in the topic 'output-stream' and prints
 
 3. model_functions.py - It has basic model based functions to train a model and get predictions from a model saved at a particular path.
 
-4. train_model.py - Can be used to train a new_model having the same architecture on a different dataset. Slight changes will have to be made to the code to load the new dataset into it. After making the changes, following command can be run to generate a new model from the command line after navigating to project folder -
+4. train_model.py - Can be used to train a new_model having the same architecture on the Fashion MNIST dataset. Following command can be run to generate a new model from the command line after navigating to project folder -
 ```
 python3 train_model.py ${epochs:int} ${model_name:str}
 ```
 In order to test the newly created model on the data streaming application, rename it to model.h5 and you would be good to go.
+
+5. train_mnist_model.py - Can be used to train a new model on the MNIST digit dataset using the same CNN architecture. Following command can be run to train a MNIST digit classification model:
+```
+python3 train_mnist_model.py ${epochs:int} ${model_name:str}
+```
+For example: `python3 train_mnist_model.py 10 mnist_model.h5`
+This will train a model for 10 epochs and save it as 'mnist_model.h5'. To use this model in the streaming application, rename it to model.h5.
+
+6. switch_models.py - A utility script to easily switch between different trained models. Usage:
+```
+python3 switch_models.py ${model_name}
+```
+For example: `python3 switch_models.py mnist_model.h5`
+This will backup the current model.h5 as model_backup.h5 and copy the specified model to model.h5.
 
 **FEW KEY THINGS TO NOTE :**
 1. While training the image classifier model I was able to get the accuracy up to 93% in the Google Colab Environment. I later tried training that model with the same data on my local MacOS machine and wasn't able to exceed 10% accuracy. I suspect this is happening because of the differences in how a CPU and GPU performs. The model that I have uploaded here is the 93% accurate one.

--- a/switch_models.py
+++ b/switch_models.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Utility script to switch between trained models.
+Usage: python3 switch_models.py <model_name>
+Example: python3 switch_models.py mnist_model.h5
+"""
+
+import sys
+import shutil
+import os
+
+def switch_model(model_name):
+    """Switch the active model by copying the specified model to model.h5"""
+    if not os.path.exists(model_name):
+        print(f"Error: Model file '{model_name}' not found!")
+        return False
+    
+    # Backup current model if it exists
+    if os.path.exists('model.h5'):
+        shutil.copy2('model.h5', 'model_backup.h5')
+        print("Current model backed up as 'model_backup.h5'")
+    
+    # Copy new model
+    shutil.copy2(model_name, 'model.h5')
+    print(f"Successfully switched to model: {model_name}")
+    return True
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print("Usage: python3 switch_models.py <model_name>")
+        print("Example: python3 switch_models.py mnist_model.h5")
+        sys.exit(1)
+    
+    model_name = sys.argv[1]
+    switch_model(model_name)

--- a/train_mnist_model.py
+++ b/train_mnist_model.py
@@ -2,7 +2,7 @@ import sys
 import tensorflow as tf
 from model_functions import train_and_save_model
 
-# Load MNIST digit dataset
+# Load MNIST digit dataset for handwritten digit classification
 mnist = tf.keras.datasets.mnist
 (x_train, y_train), _ = mnist.load_data()
 

--- a/train_mnist_model.py
+++ b/train_mnist_model.py
@@ -2,8 +2,9 @@ import sys
 import tensorflow as tf
 from model_functions import train_and_save_model
 
-fashion_mnist = tf.keras.datasets.fashion_mnist
-(x_train, y_train), _ = fashion_mnist.load_data()
+# Load MNIST digit dataset
+mnist = tf.keras.datasets.mnist
+(x_train, y_train), _ = mnist.load_data()
 
 if __name__=='__main__':
     epochs = int(sys.argv[1])


### PR DESCRIPTION
## Summary

This PR adds support for training MNIST digit classification models alongside the existing FashionMNIST capability. The MNIST model uses the same CNN architecture as defined in `model_functions.py`, ensuring consistency across both model types.

## Changes

1. **New Training Script** (`train_mnist_model.py`):
   - Loads MNIST digit dataset instead of FashionMNIST
   - Uses the same training function and CNN architecture
   - Compatible with the existing streaming infrastructure

2. **Bug Fix** in `train_model.py`:
   - Fixed incorrect type conversion of `model_name` parameter from int to string

3. **Model Management Utility** (`switch_models.py`):
   - New script to easily switch between different trained models
   - Automatically backs up the current model before switching
   - Simplifies testing different models with the streaming pipeline

4. **Documentation Updates**:
   - Added instructions for training MNIST models
   - Documented the model switching utility
   - Clarified the distinction between FashionMNIST and MNIST training scripts

## Usage

To train an MNIST digit classification model:
```bash
python3 train_mnist_model.py 10 mnist_model.h5
```

To switch to using the MNIST model:
```bash
python3 switch_models.py mnist_model.h5
```

## Testing

The MNIST model maintains the same input/output format as the FashionMNIST model (28x28 grayscale images, 10 classes), making it fully compatible with the existing pub/sub streaming infrastructure.